### PR TITLE
fix: no module named 'tornado' error in glue job

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -224,7 +224,7 @@
       "name": "postinstall",
       "steps": [
         {
-          "exec": "git submodule init && git submodule sync && git submodule update && docker run --rm -v `pwd`/src/script-libs/amazon-neptune-tools/neptune-python-utils:/src --workdir /src python:3.8-buster bash -c \"apt update && apt install -y sudo zip && rm -rf /src/target && /src/build.sh\""
+          "exec": "git submodule init && git submodule sync && git submodule update && docker run --rm -v `pwd`/src/script-libs/amazon-neptune-tools/neptune-python-utils:/src --workdir /src python:3.8-buster bash -c \"apt update && apt install -y sudo zip && rm -rf /src/target && sed -i.bak 's/gremlinpython$/gremlinpython==3.4.*/g' /src/build.sh && /src/build.sh && mv /src/build.sh.bak /src/build.sh\""
         }
       ]
     }

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -179,7 +179,7 @@ project.addTask('cdk-init', {
 });
 project.addTask('postinstall', {
   exec:
-    'git submodule init && git submodule sync && git submodule update && docker run --rm -v `pwd`/src/script-libs/amazon-neptune-tools/neptune-python-utils:/src --workdir /src python:3.8-buster bash -c "apt update && apt install -y sudo zip && rm -rf /src/target && /src/build.sh"',
+    'git submodule init && git submodule sync && git submodule update && docker run --rm -v `pwd`/src/script-libs/amazon-neptune-tools/neptune-python-utils:/src --workdir /src python:3.8-buster bash -c "apt update && apt install -y sudo zip && rm -rf /src/target && sed -i.bak \'s/gremlinpython$/gremlinpython==3.4.*/g\' /src/build.sh && /src/build.sh && mv /src/build.sh.bak /src/build.sh"',
 });
 
 const tsReactConfig = {


### PR DESCRIPTION
closes #116 

pin `gremlinpython` to 3.4.* as workaround

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*