### PR TITLE
fix: mask-out test labels during gradient updates in training loop

### DIFF
--- a/src/sagemaker/FD_SL_DGL/gnn_fraud_detection_dgl/fd_sl_train_entry_point.py
+++ b/src/sagemaker/FD_SL_DGL/gnn_fraud_detection_dgl/fd_sl_train_entry_point.py
@@ -35,6 +35,10 @@ def train_fg(model, optim, loss, features, labels, train_g, test_g, test_mask,
     A full graph verison of RGCN training
     """
 
+    # get list of indecies for train labels
+    train_mask= th.logical_not(test_mask)
+    train_idx=  th.nonzero(train_mask, as_tuple=True)[0]
+    
     duration = []
     for epoch in range(n_epochs):
         tic = time.time()
@@ -42,7 +46,9 @@ def train_fg(model, optim, loss, features, labels, train_g, test_g, test_mask,
 
         pred = model(train_g, features.to(device))
 
-        l = loss(pred, labels)
+        # only compute gradient updates for labels in train split
+        l = loss(th.index_select(pred, 0, train_idx), 
+                 th.index_select(labels, 0, train_idx))
 
         optim.zero_grad()
         l.backward()


### PR DESCRIPTION
PR contains a fix for bug in training loop that "leaked" test labels during training. The fix is to mask test labels during gradient updates. 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*